### PR TITLE
Refactoring rest naming endpoints 

### DIFF
--- a/back-end/src/main/java/dota/buff/controller/HeroController.java
+++ b/back-end/src/main/java/dota/buff/controller/HeroController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("api/v1/hero")
+@RequestMapping("api/v1/heroes")
 @RequiredArgsConstructor
 public class HeroController {
 
@@ -29,10 +29,9 @@ public class HeroController {
         return new ResponseEntity<>(heroService.getHeroById(id), HttpStatus.OK);
     }
 
-    @GetMapping("/all")
+    @GetMapping
     public ResponseEntity<List<HeroDTO>> getAllHeroes() {
         log.info("Request for get all heroes");
         return new ResponseEntity<>(heroService.getAllHeroes(), HttpStatus.OK);
     }
-
 }

--- a/back-end/src/main/java/dota/buff/controller/MatchController.java
+++ b/back-end/src/main/java/dota/buff/controller/MatchController.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/match")
+@RequestMapping("/api/v1/matches")
 @RequiredArgsConstructor
 public class MatchController {
 

--- a/back-end/src/main/java/dota/buff/controller/PlayerController.java
+++ b/back-end/src/main/java/dota/buff/controller/PlayerController.java
@@ -19,12 +19,13 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("api/v1/player")
+@RequestMapping("api/v1/players")
 @RequiredArgsConstructor
 public class PlayerController {
 
     private final PlayerService playerService;
 
+    //TODO steamId put in the path variable isn't safe, should be workable another way.
     @GetMapping("/{steamId}/matches")
     public ResponseEntity<List<SparkerMatchHistoryDetail>> getAmountPlayerMatches(@PathVariable Long steamId, @RequestParam Integer amount) {
         log.info("Request for get {} matches by steamId: {}", amount, steamId);
@@ -36,5 +37,4 @@ public class PlayerController {
         log.info("Request for get last match by steamId: {}", steamId);
         return new ResponseEntity<>(playerService.getLastMatch(steamId), HttpStatus.OK);
     }
-
 }

--- a/front-end/src/component/ImageWrapper.jsx
+++ b/front-end/src/component/ImageWrapper.jsx
@@ -8,7 +8,6 @@ export const ImageWrapper = (
         className = 'p-1'
     }
 ) => {
-    console.log(width)
     return (
         <Image className={className}
                src={imagePath}

--- a/front-end/src/index.js
+++ b/front-end/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
 import App from './App';
 import {Provider} from "react-redux";
 import {createStore} from "redux";

--- a/front-end/src/model/Hero.jsx
+++ b/front-end/src/model/Hero.jsx
@@ -8,6 +8,7 @@ export const Hero = ({hero}) => {
             <th>
                 <div>
                     <ImageWrapper className={'p-0'}
+                                  //TODO in accordance with adding a new heroes, should know that we need to upload a new image.
                                   imagePath={`dota_images/heroes/id_${hero.id}.png`}
                                   width={'125.78'}
                                   height={'63'}/>

--- a/front-end/src/page/HeroesPage.jsx
+++ b/front-end/src/page/HeroesPage.jsx
@@ -5,7 +5,7 @@ import {EntityPagination} from "../component";
 import {calculateCurrentEntitiesViaPagePagination} from "../util";
 
 export const HeroesPage = ({heroes}) => {
-    const [currentPage ,setCurrentPage] = useState(1);
+    const [currentPage, setCurrentPage] = useState(1);
     const [heroPerPage] = useState(7);
     const currentHeroes = calculateCurrentEntitiesViaPagePagination(heroes, currentPage);
 

--- a/front-end/src/service/HeroService.js
+++ b/front-end/src/service/HeroService.js
@@ -1,7 +1,7 @@
 import axios from "axios";
-import {ALL, HERO_URL} from "../util";
+import {HERO_URL} from "../util";
 import {axiosHandler} from "./";
 
 export const getHeroById = async id => await axiosHandler(axios.get(HERO_URL.concat(id)));
 
-export const getAllHeroes = async () => await axiosHandler(axios.get(HERO_URL.concat(ALL)));
+export const getAllHeroes = async () => await axiosHandler(axios.get(HERO_URL));

--- a/front-end/src/util/Constants.js
+++ b/front-end/src/util/Constants.js
@@ -1,29 +1,27 @@
 export const BASE_URL = 'http://localhost:8080/api/v1';
 
-export const PLAYER = '/player';
-export const MATCH = '/match';
-export const HERO = '/hero';
+export const PLAYERS = '/players';
+export const MATCHES = '/matches';
+export const HEROES = '/heroes';
 export const ID = '/$id$';
 
-export const ALL = '/all';
 export const SLASH = '/';
 
-export const HERO_URL =  BASE_URL + HERO;
+export const HERO_URL =  BASE_URL + HEROES;
 export const HERO_BY_ID_URL =  HERO_URL + ID;
-export const ALL_HEROES_URL =  BASE_URL + HERO + ALL;
+export const ALL_HEROES_URL =  HERO_URL;
 
-export const MATCH_URL = BASE_URL + MATCH;
+export const MATCH_URL = BASE_URL + MATCHES;
 export const MATCH_BY_ID_URL = MATCH_URL + ID;
-export const ALL_MATCH_PLAYERS_BY_MATCH_ID_URL = MATCH_URL + '/players' + MATCH + ID;
-export const ALL_MATCH_HEROES_BY_MATCH_ID_URL = MATCH_URL + '/heroes' + MATCH;
-export const MATCH_WINNER_BY_MATCH_ID_URL = MATCH_URL + '/winner' + MATCH;
+export const ALL_MATCH_PLAYERS_BY_MATCH_ID_URL = MATCH_URL + PLAYERS + MATCHES + ID;
+export const ALL_MATCH_HEROES_BY_MATCH_ID_URL = MATCH_URL + HEROES + MATCHES;
+export const MATCH_WINNER_BY_MATCH_ID_URL = MATCH_URL + '/winner' + MATCHES;
 
-export const PLAYER_URL = BASE_URL + '/player';
+export const PLAYER_URL = BASE_URL + PLAYERS;
 export const LAST_PLAYER_MATCH_BY_STEAM_ID_URL = PLAYER_URL + ID;
-export const FIXED_NUMBER_PLAYER_MATCHES = PLAYER_URL + ID + '/matches';
+export const FIXED_NUMBER_PLAYER_MATCHES = PLAYER_URL + ID + MATCHES;
 
 export const PATH_TO_MAIN_PAGE = '/';
-export const PATH_TO_MATCHES_PAGE = '/matches'
+export const PATH_TO_MATCHES_PAGE = MATCHES;
 
 export const STEAM_ID = 76561198087981013;
-export const HEROES = 'heroes';

--- a/front-end/src/util/index.js
+++ b/front-end/src/util/index.js
@@ -1,10 +1,9 @@
 import {
     BASE_URL,
-    PLAYER,
-    MATCH,
-    HERO,
+    PLAYERS,
+    MATCHES,
+    HEROES,
     ID,
-    ALL,
     SLASH,
     HERO_URL,
     HERO_BY_ID_URL,
@@ -20,7 +19,6 @@ import {
     STEAM_ID,
     PATH_TO_MAIN_PAGE,
     PATH_TO_MATCHES_PAGE,
-    HEROES
 } from './Constants'
 
 import {secondsToMinutesConverter} from './SecondsConverter'
@@ -28,11 +26,10 @@ import {calculateCurrentEntitiesViaPagePagination} from './EntityCalculator'
 
 export {
     BASE_URL,
-    PLAYER,
-    MATCH,
-    HERO,
+    PLAYERS,
+    MATCHES,
+    HEROES,
     ID,
-    ALL,
     SLASH,
     HERO_URL,
     HERO_BY_ID_URL,
@@ -48,7 +45,6 @@ export {
     STEAM_ID,
     PATH_TO_MAIN_PAGE,
     PATH_TO_MATCHES_PAGE,
-    HEROES,
     secondsToMinutesConverter,
     calculateCurrentEntitiesViaPagePagination
 }


### PR DESCRIPTION
In accordance with some documentation ab constraints in the REST API, one of the points is to use the plural form
E.g. [Naming constraints Rest api](https://nordicapis.com/10-best-practices-for-naming-api-endpoints/)